### PR TITLE
NL #90 - Routing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
 	<!-- Shim for JWT when this is called standalone -->
 	<script>
         window.baseRoute = '';
+        window.baseUrl = '';
     </script>
 </head>
 

--- a/src/sagas/api_helper.js
+++ b/src/sagas/api_helper.js
@@ -7,7 +7,7 @@ export const recordsEndpoint = 'neatline_records';
 const API_ROOT = '/api/';
 
 export const urlFormat = (endpoint, params = {}, id = null) => {
-  let url = `${API_ROOT}${endpoint}`;
+  let url = `${window.baseUrl}${API_ROOT}${endpoint}`;
   if (id) {
     url += '/' + id;
   }


### PR DESCRIPTION
This pull request updates the `api_helper` to use the `baseUrl` attribute from the `window` object when creating the API URL.

**Note:** This pull request also has a dependent [pull request](https://github.com/performant-software/neatline-omeka-s/pull/6) in the neatline-omeka-s repo.